### PR TITLE
base64.cpp->Base64.cpp@AEDLib.h

### DIFF
--- a/AESLib.h
+++ b/AESLib.h
@@ -3,7 +3,7 @@
 
 #include "Arduino.h"
 #include "AES.h"
-#include "base64.h"
+#include "Base64.h"
 
 class AESLib
 {


### PR DESCRIPTION
Hi kakopappa.

I'm so grateful for your AES Library for esp8266.

But on my environment, other library has base64.h, so compilation of AESLib.cpp was failed with a message "error: 'base64_encode' was not declared in this scope".

On the other hand, your library has not "base64.h" but "Base64.h", so I modified " #include "base64.h" " to " #include "Base64.h" ".

I would appreciate it if you could pull this change.

Thank you!!